### PR TITLE
Add SvelteHTMLElements interface to type-generator

### DIFF
--- a/src/type-generator.ts
+++ b/src/type-generator.ts
@@ -343,6 +343,10 @@ declare global {
   }
   ${cssPropertiesTemplate}
 }
+
+declare module 'svelte/elements' {
+  export interface SvelteHTMLElements extends CustomElements { }
+}
 `;
 }
 


### PR DESCRIPTION
Cf https://svelte.dev/docs/svelte/typescript#Enhancing-built-in-DOM-types

ℹ️ I'm not sure svelte support typing the css properties, so I'm only adding the types for tags