### PR TITLE
fix: type-generator creating broken import due to re-export

### DIFF
--- a/.changeset/real-crabs-dance.md
+++ b/.changeset/real-crabs-dance.md
@@ -1,0 +1,5 @@
+---
+"@wc-toolkit/jsx-types": patch
+---
+
+Fix generator creating invalid imports (like `import type { * }`) when using un-namespaced wildcard exports

--- a/src/type-generator.ts
+++ b/src/type-generator.ts
@@ -109,7 +109,7 @@ function getImports(manifest: cem.Package, options: JsxTypesOptions) {
         module.exports?.forEach((e) => {
           const exportName = e.declaration.name;
 
-          if (!exportName || moduleNames.includes(exportName)) {
+          if (!exportName || exportName === "*" || moduleNames.includes(exportName)) {
             return;
           }
           moduleNames.push(exportName);


### PR DESCRIPTION
### Description

The type-generator can create a broken import in the `custom-element-jsx.d.ts` declaration file, due to mishandled re-export without namespace. 

This happens because `getImports` assumes that all module names (that aren't falsy) are correct, however based on https://github.com/open-wc/custom-elements-manifest/blob/df0795b2bdd41a8109fa531ce00edae025726c1a/packages/analyzer/src/features/analyse-phase/exports.js#L101C15-L101C66

It seems that re-exports that aren't namespaced will fallback to `"*"` which isn't a valid module name when imported in JavaScript.

I'm not sure whether the implementation in https://github.com/webcomponents/custom-elements-manifest is desirable in the first place though.

### To reproduce

1. Change `demo/basic/src/my-component.js` to `demo/basic/src/my-component.ts`
2. Create the following file `demo/basic/src/test.ts` with the following contents

```ts
export const test = "test";
```

4. Add the following line to the `demo/basic/src/my-component.ts` file

```ts
export * from "./test";
```

> Note: Make sure to also update `this.shadowRoot.innerHTML` to `this.shadowRoot!.innerHTML` as it's nullable.

5. Change `import manifest from "./shoelace-cem.json"` in `demo/basic/generate-types.js` to:

```ts
import manifest from "../custom-elements.json" with { type: "json" };
```

6. Then update the `analyze` script (in the `package.json` file) to match for `*.ts` files instead.

7. Lastly run the following scripts:

```sh
npm run analyze
npm run demo
```

### Expected

The `npm run demo` command to run successfully without the asterisk in the type import. 

### Stacktrace

```
node:internal/modules/run_main:107
    triggerUncaughtException(
    ^

SyntaxError: Identifier expected. (2:15)
  1 |
> 2 | import type { *, MyComponent } from "demo/basic/src/my-component.ts";
    |               ^
  3 |
```

### Details

This is what the `custom-elements.json` file contains after running `npm run analyze` when including the following 2 re-exports:

```ts
export * from "./test" // This results in a broken declaration file
export * as test from "./test" // This is fine
```

```json
      "exports": [
        {
          "kind": "js",
          "name": "*",
          "declaration": {
            "name": "*",
            "module": "demo/basic/src/test"
          }
        },
        {
          "kind": "js",
          "name": "*",
          "declaration": {
            "name": "test",
            "module": "demo/basic/src/test"
          }
        },
```
