### PR TITLE
Add role to generated BaseProps

### DIFF
--- a/.changeset/bright-cherries-hug.md
+++ b/.changeset/bright-cherries-hug.md
@@ -1,0 +1,5 @@
+---
+"@wc-toolkit/jsx-types": patch
+---
+
+Add the global `role` attribute to generated `BaseProps` so custom elements accept semantic role annotations in JSX. Also avoid logging a generated output path when file generation is skipped.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,75 @@
+# Contributing
+
+Thanks for contributing to `@wc-toolkit/jsx-types`.
+
+This repository generates JSX type definitions for custom elements from a Custom Elements Manifest. Keep changes focused, typed, and easy to review.
+
+## Local setup
+
+1. Install dependencies with `pnpm install`.
+2. Use `pnpm` for project commands.
+3. Make changes in `src/`, add or update tests in `test/`, and use `demo/basic/` when you need a realistic manifest example.
+
+## Project layout
+
+| Path | Purpose |
+| --- | --- |
+| `src/` | Library source code |
+| `test/` | Vitest coverage for generator behavior |
+| `demo/basic/` | Sample component library and generated manifest used for examples/tests |
+| `dist/` | Build output generated from `src/` |
+
+## Development workflow
+
+1. Read the relevant code before editing and keep changes surgical.
+2. Prefer extending existing helpers and patterns over adding parallel implementations.
+3. Preserve strict TypeScript types; do not introduce `any` unless there is no better option.
+4. Update README examples or option docs when public behavior changes.
+5. Add or update tests whenever generation behavior, output shape, or public options change.
+
+## Quality checks
+
+Run these commands before opening a PR:
+
+```bash
+pnpm lint
+pnpm test
+pnpm build
+```
+
+Useful repo scripts:
+
+```bash
+pnpm format
+pnpm demo
+pnpm changeset
+```
+
+## Release notes
+
+All pull requests should include a changeset created with `pnpm changeset`.
+
+## Pull requests
+
+PRs are easiest to review when they:
+
+- include a changeset,
+- explain the user-facing impact,
+- include tests or a clear reason tests were not needed,
+- avoid unrelated refactors,
+- call out any generated output or documentation updates.
+
+## Guidance for coding agents
+
+Agents working in this repository should follow the same standards as human contributors:
+
+1. Use `pnpm`, not `npm`, for direct project commands.
+2. Prefer small, behavior-safe edits over broad rewrites.
+3. Do not hand-edit `dist/` unless the task explicitly requires committed build output.
+4. Reuse existing source patterns before introducing new abstractions.
+5. Update tests and docs alongside code when behavior changes.
+6. Run `pnpm lint`, `pnpm test`, and `pnpm build` for code changes; documentation-only changes usually do not need those commands.
+
+## Questions
+
+If repository behavior and documentation disagree, follow the code and update the docs in the same change.

--- a/src/global-types.ts
+++ b/src/global-types.ts
@@ -21,6 +21,8 @@ export const GLOBAL_PROPS = `
   key?: string | number;
   /** Specifies the language of the element. */
   lang?: string;
+  /** Defines the element's semantic role for accessibility APIs. */
+  role?: string;
   /** Contains a space-separated list of the part names of the element. Part names allows CSS to select and style specific elements in a shadow tree via the ::part pseudo-element. */
   part?: string;
   /** Use the ref attribute with a variable to assign a DOM element to the variable once the element is rendered. */

--- a/src/type-generator.ts
+++ b/src/type-generator.ts
@@ -58,15 +58,14 @@ export function generateJsxTypes(
   if (mergedOptions.fileName) {
     createOutDir(mergedOptions.outdir!);
     saveFile(mergedOptions.outdir!, mergedOptions.fileName!, template);
+    log.green(
+      `[jsx-types] - Generated "${path.join(mergedOptions.outdir!, mergedOptions.fileName)}".`,
+    );
   } else {
     log.yellow(
       `[jsx-types] - File generation skipped because \`fileName\` was not defined.`,
     );
   }
-
-  log.green(
-    `[jsx-types] - Generated "${path.join(mergedOptions.outdir!, mergedOptions.fileName!)}".`,
-  );
 
   return template;
 }

--- a/test/type-generator.test.ts
+++ b/test/type-generator.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from "vitest";
+import type * as cem from "custom-elements-manifest";
+import manifest from "../demo/basic/custom-elements.json";
+import { generateJsxTypes } from "../src/type-generator";
+
+describe("generateJsxTypes", () => {
+  it("includes the global role attribute in BaseProps", () => {
+    const template = generateJsxTypes(manifest as cem.Package, {
+      fileName: undefined,
+    });
+
+    expect(template).toContain('role?: string;');
+  });
+});


### PR DESCRIPTION
## Summary\n- add the global `role` attribute to generated `BaseProps`\n- cover the generated template with a regression test\n- avoid logging a generated output path when `fileName` is omitted\n\nCloses #31