### PR TITLE
Add CEM-backed prop typing options

### DIFF
--- a/.changeset/green-teachers-double.md
+++ b/.changeset/green-teachers-double.md
@@ -1,0 +1,10 @@
+---
+"@wc-toolkit/jsx-types": minor
+---
+
+Add CEM-backed prop typing with the new `useCemTypes` and `typesSrc` options.
+
+When `useCemTypes` is enabled, generated JSX prop types can read from configurable
+CEM type properties and now import referenced named types so those annotations are
+available in the output. The pre-commit hook now also runs the build to catch type
+and packaging errors before commit.

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+pnpm build
 npx lint-staged

--- a/README.md
+++ b/README.md
@@ -232,6 +232,29 @@ The `JsxTypesOptions` interface provides several configuration options to custom
 }
 ```
 
+#### `useCemTypes`
+- **Type:** `boolean`
+- **Default:** `false`
+- **Description:** Uses the property types extracted into the custom elements manifest instead of generating prop types from the imported component class. This is especially useful for JavaScript components whose typings come from JSDoc or other CEM plugins.
+
+```ts
+{
+  useCemTypes: true
+}
+```
+
+#### `typesSrc`
+- **Type:** `string`
+- **Default:** `"type"`
+- **Description:** Property name on the CEM member or attribute to read types from when `useCemTypes` is enabled. This is useful when another tool like the [@wc-toolkit/type-parser](https://www.npmjs.com/package/@wc-toolkit/type-parser) adds alternate type properties such as `parsedType`.
+
+```ts
+{
+  useCemTypes: true,
+  typesSrc: "parsedType"
+}
+```
+
 #### `excludeCssCustomProperties`
 - **Type:** `boolean`
 - **Default:** `false`
@@ -501,6 +524,8 @@ generateJsxTypes(manifest, {
   
   // Additional features
   allowUnknownProps: false,
+  useCemTypes: true,
+  typesSrc: "parsedType",
   excludeCssCustomProperties: false,
   
   // Development

--- a/src/type-generator.ts
+++ b/src/type-generator.ts
@@ -4,8 +4,8 @@ import { JsxTypesOptions } from "./types";
 import {
   Component,
   getAllComponents,
-  getAttrsAndProps,
   getComponentDetailsTemplate,
+  getComponentPublicProperties,
   getMemberDescription,
   toPascalCase,
 } from "@wc-toolkit/cem-utilities";
@@ -71,9 +71,8 @@ export function generateJsxTypes(
 }
 
 function getImports(manifest: cem.Package, options: JsxTypesOptions) {
-  const importTemplates: string[] = [];
-  let modules: string[] = [];
-  const moduleNames: string[] = [];
+  const imports = new Map<string, Set<string>>();
+  const componentModules = new Map<string, { modulePath: string; tagName?: string }>();
 
   manifest.modules.forEach((module) => {
     if (
@@ -84,63 +83,102 @@ function getImports(manifest: cem.Package, options: JsxTypesOptions) {
       return;
     }
 
+    module.declarations?.forEach((element) => {
+      const component = element as cem.CustomElement;
+
+      if (!component.customElement || !component.name) {
+        return;
+      }
+
+      componentModules.set(component.name, {
+        modulePath: module.path,
+        tagName: component.tagName,
+      });
+    });
+
     if (options.globalTypePath) {
-      // If a global type path is provided, we import all components as a single import
-      modules = [
-        ...new Set([
-          ...modules,
-          ...(module.exports?.map((e) => e.declaration.name) || []),
-        ]),
-      ];
-    } else {
-      module.declarations?.forEach((element) => {
-        const component = element as cem.CustomElement;
-        const importPath =
-          typeof options.componentTypePath === "function"
-            ? options.componentTypePath?.(
-                component.name,
-                component.tagName,
-                module.path,
-              )
-            : module.path;
-        const uniqueExports: string[] = [];
+      module.exports?.forEach((exportDeclaration) => {
+        const exportName = exportDeclaration.declaration.name;
 
-        module.exports?.forEach((e) => {
-          const exportName = e.declaration.name;
-
-          if (!exportName || exportName === "*" || moduleNames.includes(exportName)) {
-            return;
-          }
-          moduleNames.push(exportName);
-          uniqueExports.push(exportName);
-        });
-
-        if (!uniqueExports?.length) {
+        if (!exportName || exportName === "*") {
           return;
         }
 
-        if (options.defaultExport) {
-          uniqueExports.push(`default as ${component.name}`);
+        addImport(imports, options.globalTypePath!, exportName);
+      });
+    } else {
+      module.declarations?.forEach((element) => {
+        const component = element as cem.CustomElement;
+
+        if (!component.customElement || !component.name) {
+          return;
         }
 
-        const exportList = options.defaultExport
-          ? uniqueExports
-              ?.filter((x) =>
-                options.defaultExport ? x !== component.name : false,
-              )
-              .join(", ")
-          : uniqueExports?.join(", ");
+        const importPath =
+          getComponentImportPath(component.name, component.tagName, module.path, options);
 
-        importTemplates.push(
-          `import type { ${exportList} } from "${importPath}";`,
-        );
+        module.exports?.forEach((exportDeclaration) => {
+          const exportName = exportDeclaration.declaration.name;
+
+          if (!exportName || exportName === "*") {
+            return;
+          }
+
+          if (!(options.defaultExport && exportName === component.name)) {
+            addImport(imports, importPath, exportName);
+          }
+        });
+
+        if (options.defaultExport) {
+          addImport(imports, importPath, `default as ${component.name}`);
+        }
       });
     }
   });
 
-  return options.globalTypePath
-    ? `import type { ${modules.join(", ")} } from "${options.globalTypePath}";`
-    : importTemplates.join("\n");
+  if (options.useCemTypes) {
+    getAllComponents(manifest, options.exclude).forEach((component) => {
+      if (!component.name) {
+        return;
+      }
+
+      const componentModule = componentModules.get(component.name);
+
+      if (!componentModule) {
+        return;
+      }
+
+      getComponentProps(component).forEach((prop) => {
+        const propType = getResolvedPropType(prop, options);
+
+        propType?.references?.forEach((reference) => {
+          if (!reference.name || reference.name === "default") {
+            return;
+          }
+
+          const importPath = getTypeImportPath(
+            reference,
+            componentModule.modulePath,
+            component,
+            options,
+          );
+
+          if (!importPath) {
+            return;
+          }
+
+          addImport(imports, importPath, reference.name);
+        });
+      });
+    });
+  }
+
+  return Array.from(imports.entries())
+    .map(
+      ([importPath, exportNames]) =>
+        `import type { ${Array.from(exportNames).join(", ")} } from "${importPath}";`,
+    )
+    .join("\n");
 }
 
 function getTypeTemplate(manifest: cem.Package, options: JsxTypesOptions) {
@@ -209,9 +247,8 @@ ${components
     }
 
     const cachedProps =
-      getAttrsAndProps(component)?.filter(
-        (prop) => !prop.readonly && !prop.static,
-      ) || [];
+      getComponentProps(component)?.filter((prop) => !prop.readonly && !prop.static) ||
+      [];
 
     const strongEventTypes = getStrongEventTypes(component);
 
@@ -228,9 +265,8 @@ ${(() => {
 
   return cachedProps.reduce((acc, prop) => {
     const description = getMemberDescription(prop.description, prop.deprecated);
-    const type = prop.propName
-      ? `${component.name}['${prop.propName}']`
-      : "unknown";
+    const typeInfo = getResolvedPropType(prop, options);
+    const type = getPropType(component.name, prop, typeInfo, options);
 
     // Check if we already have this property in the accumulator
     const propExists = acc.includes(`  "${prop.propName}"?:`);
@@ -245,7 +281,7 @@ ${(() => {
           "${prop.attrName}"?: ${type};\n`;
       }
       solidTypes += `  /** ${description} */
-        "${prop.type?.text.includes("boolean") ? "bool" : "attr"}:${prop.attrName}"?: ${type};\n`;
+        "${(typeInfo?.text || prop.type?.text || "").includes("boolean") ? "bool" : "attr"}:${prop.attrName}"?: ${type};\n`;
     }
 
     // Add property declaration if it doesn't exist yet
@@ -431,6 +467,160 @@ declare global {
   ${cssPropertiesTemplate}
 }
 `;
+}
+
+type ComponentProp = {
+  attrName?: string;
+  propName?: string;
+  description?: string;
+  deprecated?: boolean | string;
+  readonly?: boolean;
+  static?: boolean;
+  type?: cem.Type;
+  attribute?: cem.Attribute;
+  property?: cem.ClassField;
+};
+
+function addImport(
+  imports: Map<string, Set<string>>,
+  importPath: string,
+  exportName: string,
+) {
+  const existing = imports.get(importPath);
+
+  if (existing) {
+    existing.add(exportName);
+    return;
+  }
+
+  imports.set(importPath, new Set([exportName]));
+}
+
+function getComponentImportPath(
+  componentName: string,
+  tagName: string | undefined,
+  modulePath: string,
+  options: JsxTypesOptions,
+) {
+  return typeof options.componentTypePath === "function"
+    ? options.componentTypePath(componentName, tagName, modulePath)
+    : modulePath;
+}
+
+function getTypeImportPath(
+  reference: cem.TypeReference,
+  componentModulePath: string,
+  component: Component,
+  options: JsxTypesOptions,
+) {
+  if (reference.package) {
+    return reference.package;
+  }
+
+  if (!reference.module) {
+    return null;
+  }
+
+  if (reference.module === componentModulePath) {
+    if (options.globalTypePath) {
+      return options.globalTypePath;
+    }
+
+    if (component.name) {
+      return getComponentImportPath(
+        component.name,
+        component.tagName,
+        componentModulePath,
+        options,
+      );
+    }
+  }
+
+  return reference.module;
+}
+
+function getComponentProps(component: Component): ComponentProp[] {
+  const properties = getComponentPublicProperties(component) as cem.ClassField[];
+  const propertyMap = new Map(properties.map((property) => [property.name, property]));
+  const attributeProps =
+    component.attributes?.map((attribute) => ({
+      attrName: attribute.name,
+      propName: attribute.fieldName,
+      description: attribute.description,
+      deprecated: attribute.deprecated,
+      readonly: false,
+      static: false,
+      type: attribute.type,
+      attribute,
+      property: attribute.fieldName
+        ? propertyMap.get(attribute.fieldName)
+        : undefined,
+    })) || [];
+  const attributePropNames = new Set(
+    attributeProps
+      .map((attribute) => attribute.propName)
+      .filter((propName): propName is string => Boolean(propName)),
+  );
+  const propertyOnlyProps = properties
+    .filter((property) => !attributePropNames.has(property.name))
+    .map((property) => ({
+      attrName: undefined,
+      propName: property.name,
+      description: property.description,
+      deprecated: property.deprecated,
+      readonly: property.readonly,
+      static: property.static,
+      type: property.type,
+      attribute: undefined,
+      property,
+    }));
+
+  return [...attributeProps, ...propertyOnlyProps];
+}
+
+function getTypeFromSource(
+  source: cem.Attribute | cem.ClassField | undefined,
+  sourceKey: string,
+) {
+  const candidate = source
+    ? (source as unknown as Record<string, unknown>)[sourceKey]
+    : undefined;
+
+  if (
+    candidate &&
+    typeof candidate === "object" &&
+    "text" in candidate &&
+    typeof candidate.text === "string"
+  ) {
+    return candidate as cem.Type;
+  }
+
+  return undefined;
+}
+
+function getResolvedPropType(prop: ComponentProp, options: JsxTypesOptions) {
+  const sourceKey = options.typesSrc || "type";
+
+  return (
+    getTypeFromSource(prop.property, sourceKey) ??
+    getTypeFromSource(prop.attribute, sourceKey) ??
+    (sourceKey === "type" ? undefined : getTypeFromSource(prop.property, "type")) ??
+    (sourceKey === "type" ? undefined : getTypeFromSource(prop.attribute, "type")) ??
+    prop.type
+  );
+}
+
+function getPropType(
+  componentName: string,
+  prop: ComponentProp,
+  propType: cem.Type | undefined,
+  options: JsxTypesOptions,
+) {
+  if (options.useCemTypes) {
+    return propType?.text || "unknown";
+  }
+
+  return prop.propName ? `${componentName}['${prop.propName}']` : "unknown";
 }
 
 function getEventTypeName(

--- a/src/types.ts
+++ b/src/types.ts
@@ -25,6 +25,10 @@ export type JsxTypesOptions = {
   globalEvents?: string;
   /** Adds types to allow users to add undefined attributes or props to the custom elements */
   allowUnknownProps?: boolean;
+  /** Use prop types extracted into the custom elements manifest instead of referencing the component class */
+  useCemTypes?: boolean;
+  /** Property name on the CEM member/attribute to read types from */
+  typesSrc?: string;
   /** Exclude types for CSS custom properties */
   excludeCssCustomProperties?: boolean;
   /** Optional function to format tag names before processing. */

--- a/test/type-generator.test.ts
+++ b/test/type-generator.test.ts
@@ -3,6 +3,179 @@ import type * as cem from "custom-elements-manifest";
 import manifest from "../demo/basic/custom-elements.json";
 import { generateJsxTypes } from "../src/type-generator";
 
+type ExtendedClassField = cem.ClassField & {
+  parsedType?: cem.Type;
+};
+
+type ExtendedCustomElement = cem.CustomElement & {
+  members?: ExtendedClassField[];
+};
+
+type ExtendedJavaScriptModule = cem.JavaScriptModule & {
+  declarations?: ExtendedCustomElement[];
+};
+
+type ExtendedPackage = cem.Package & {
+  modules: ExtendedJavaScriptModule[];
+};
+
+const jsDocManifest = {
+  schemaVersion: "1.0.0",
+  readme: "",
+  modules: [
+    {
+      kind: "javascript-module",
+      path: "src/button.js",
+      declarations: [
+        {
+          kind: "class",
+          name: "Button",
+          tagName: "x-button",
+          customElement: true,
+          attributes: [
+            {
+              name: "text",
+              fieldName: "text",
+              description: "Button text",
+              type: {
+                text: "string",
+              },
+            },
+          ],
+          members: [
+            {
+              kind: "field",
+              name: "text",
+              description: "Button text",
+              type: {
+                text: "string",
+              },
+            },
+            {
+              kind: "field",
+              name: "variant",
+              description: "Button variant",
+              type: {
+                text: '"primary" | "secondary"',
+              },
+            },
+          ],
+        },
+      ],
+      exports: [
+        {
+          kind: "js",
+          name: "Button",
+          declaration: {
+            name: "Button",
+            module: "src/button.js",
+          },
+        },
+        {
+          kind: "custom-element-definition",
+          name: "x-button",
+          declaration: {
+            name: "Button",
+            module: "src/button.js",
+          },
+        },
+      ],
+    },
+  ],
+} satisfies cem.Package;
+
+const namedTypeManifest = {
+  schemaVersion: "1.0.0",
+  readme: "",
+  modules: [
+    {
+      kind: "javascript-module",
+      path: "src/button.js",
+      declarations: [
+        {
+          kind: "class",
+          name: "Button",
+          tagName: "x-button",
+          customElement: true,
+          members: [
+            {
+              kind: "field",
+              name: "variant",
+              description: "Button variant",
+              type: {
+                text: "ButtonVariant | undefined",
+                references: [
+                  {
+                    name: "ButtonVariant",
+                    module: "src/button.js",
+                  },
+                ],
+              },
+            },
+            {
+              kind: "field",
+              name: "size",
+              description: "Button size",
+              type: {
+                text: "ButtonSize",
+                references: [
+                  {
+                    name: "ButtonSize",
+                    module: "src/button-types.js",
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+      exports: [
+        {
+          kind: "js",
+          name: "Button",
+          declaration: {
+            name: "Button",
+            module: "src/button.js",
+          },
+        },
+      ],
+    },
+  ],
+} satisfies cem.Package;
+
+const parsedTypeManifest: ExtendedPackage = {
+  ...jsDocManifest,
+  modules: [
+    {
+      ...jsDocManifest.modules[0],
+      declarations: [
+        {
+          ...jsDocManifest.modules[0].declarations![0],
+          members: [
+            {
+              kind: "field",
+              name: "variant",
+              description: "Button variant",
+              type: {
+                text: "ButtonVariant",
+                references: [
+                  {
+                    name: "ButtonVariant",
+                    module: "src/button.js",
+                  },
+                ],
+              },
+              parsedType: {
+                text: '"primary" | "secondary"',
+              },
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
 describe("generateJsxTypes", () => {
   it("includes the global role attribute in BaseProps", () => {
     const template = generateJsxTypes(manifest as cem.Package, {
@@ -10,5 +183,51 @@ describe("generateJsxTypes", () => {
     });
 
     expect(template).toContain('role?: string;');
+  });
+
+  it("keeps component property references by default", () => {
+    const template = generateJsxTypes(jsDocManifest, {
+      fileName: undefined,
+    });
+
+    expect(template).toContain(`"text"?: Button['text'];`);
+    expect(template).toContain(`"variant"?: Button['variant'];`);
+  });
+
+  it("uses manifest prop types when useCemTypes is enabled", () => {
+    const template = generateJsxTypes(jsDocManifest, {
+      fileName: undefined,
+      useCemTypes: true,
+    });
+
+    expect(template).toContain('"text"?: string;');
+    expect(template).toContain('"variant"?: "primary" | "secondary";');
+  });
+
+  it("uses the configured CEM type source when typesSrc is provided", () => {
+    const template = generateJsxTypes(parsedTypeManifest, {
+      fileName: undefined,
+      useCemTypes: true,
+      typesSrc: "parsedType",
+    });
+
+    expect(template).toContain('"variant"?: "primary" | "secondary";');
+    expect(template).not.toContain('"variant"?: ButtonVariant;');
+  });
+
+  it("imports named CEM type references when useCemTypes is enabled", () => {
+    const template = generateJsxTypes(namedTypeManifest, {
+      fileName: undefined,
+      useCemTypes: true,
+    });
+
+    expect(template).toContain(
+      'import type { Button, ButtonVariant } from "src/button.js";',
+    );
+    expect(template).toContain(
+      'import type { ButtonSize } from "src/button-types.js";',
+    );
+    expect(template).toContain('"variant"?: ButtonVariant | undefined;');
+    expect(template).toContain('"size"?: ButtonSize;');
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,8 +26,8 @@
 
     /* Modules */
     "module": "ESNext" /* Specify what module code is generated. */,
-    // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    "moduleResolution": "node" /* Specify how TypeScript looks up a file from a given module specifier. */,
+    "rootDir": "." /* Specify the root folder within your source files. */,
+    "moduleResolution": "bundler" /* Specify how TypeScript looks up a file from a given module specifier. */,
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     "paths": {
       "custom-elements-manifest": [
@@ -36,7 +36,7 @@
     } /* Specify a set of entries that re-map imports to additional lookup locations. */,
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
     // "typeRoots": [],                                  /* Specify multiple folders that act like './node_modules/@types'. */
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
+    "types": ["node"] /* Specify type package names to be included without being referenced in a source file. */,
     // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
     // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
     "resolveJsonModule": true /* Enable importing .json files. */,


### PR DESCRIPTION
## Summary
- add `useCemTypes` and `typesSrc` so generated JSX props can read from configurable CEM type properties
- import referenced named CEM types and add coverage for default, custom source, and named-type flows
- run `pnpm build` from the husky pre-commit hook and add a changeset

## Testing
- pnpm test
- pnpm lint
- pnpm build