### PR TITLE
feat: add type declarations for react/jsx-runtime and react/jsx-dev-runtime

### DIFF
--- a/.changeset/smooth-dodos-doubt.md
+++ b/.changeset/smooth-dodos-doubt.md
@@ -1,0 +1,11 @@
+---
+"@wc-toolkit/jsx-types": minor
+---
+
+Add type declarations for react/jsx-runtime and react/jsx-dev-runtime
+
+When using the modern JSX transform (`"jsx": "react-jsx"`), TypeScript
+resolves JSX types through `react/jsx-runtime` and `react/jsx-dev-runtime`,
+not the top-level `"react"` module. These new module augmentations ensure
+IntrinsicElements and CSSProperties are available for consumers using the
+automatic runtime.

--- a/demo/basic/types/custom-element-jsx.d.ts
+++ b/demo/basic/types/custom-element-jsx.d.ts
@@ -117,6 +117,8 @@ type BaseProps<T extends HTMLElement> = {
   key?: string | number;
   /** Specifies the language of the element. */
   lang?: string;
+  /** Defines the element's semantic role for accessibility APIs. */
+  role?: string;
   /** Contains a space-separated list of the part names of the element. Part names allows CSS to select and style specific elements in a shadow tree via the ::part pseudo-element. */
   part?: string;
   /** Use the ref attribute with a variable to assign a DOM element to the variable once the element is rendered. */
@@ -10046,6 +10048,20 @@ export type CustomCssProperties = {
 };
 
 declare module "react" {
+  namespace JSX {
+    interface IntrinsicElements extends CustomElements {}
+  }
+  export interface CSSProperties extends CustomCssProperties {}
+}
+
+declare module "react/jsx-runtime" {
+  namespace JSX {
+    interface IntrinsicElements extends CustomElements {}
+  }
+  export interface CSSProperties extends CustomCssProperties {}
+}
+
+declare module "react/jsx-dev-runtime" {
   namespace JSX {
     interface IntrinsicElements extends CustomElements {}
   }

--- a/src/type-generator.ts
+++ b/src/type-generator.ts
@@ -418,6 +418,20 @@ declare module 'react' {
   ${cssPropertiesTemplate}
 }
 
+declare module 'react/jsx-runtime' {
+  namespace JSX {
+    interface IntrinsicElements extends CustomElements {}
+  }
+  ${cssPropertiesTemplate}
+}
+
+declare module 'react/jsx-dev-runtime' {
+  namespace JSX {
+    interface IntrinsicElements extends CustomElements {}
+  }
+  ${cssPropertiesTemplate}
+}
+
 declare module 'preact' {
   namespace JSX {
     interface IntrinsicElements extends CustomElements {}


### PR DESCRIPTION
When using the modern JSX transform (`"jsx": "react-jsx"`), TypeScript resolves JSX types through `react/jsx-runtime` and `react/jsx-dev-runtime`, not the top-level `"react"` module. These new module augmentations ensure `IntrinsicElements` and `CSSProperties` are available for consumers using the automatic runtime.

Closes #39