### PR TITLE
fix: strongly typed CustomEvent detail types in generated .d.ts

### DIFF
--- a/.changeset/pretty-glasses-exercise.md
+++ b/.changeset/pretty-glasses-exercise.md
@@ -1,0 +1,5 @@
+---
+"@wc-toolkit/jsx-types": patch
+---
+
+Fix strongly typed CustomEvent detail types in generated .d.ts. Events whose detail is a named type (e.g. `CustomEvent<MyDetail>`) now import the detail type alongside the component element so the alias resolves. Only single named identifiers are recovered and imported; unions, nested generics, arrays and namespaced details have no single importable name and are left as-is. Events with a bare `CustomEvent`/`Event` type and components without typed event details are unaffected.

--- a/src/type-generator.ts
+++ b/src/type-generator.ts
@@ -173,6 +173,42 @@ function getImports(manifest: cem.Package, options: JsxTypesOptions) {
     });
   }
 
+  getAllComponents(manifest, options.exclude).forEach((component) => {
+    if (!component.name || !component.events?.length) {
+      return;
+    }
+
+    const componentModule = componentModules.get(component.name);
+    if (!componentModule) {
+      return;
+    }
+
+    const importPath = options.globalTypePath
+      ? options.globalTypePath
+      : getComponentImportPath(
+          component.name,
+          component.tagName,
+          componentModule.modulePath,
+          options,
+        );
+
+    component.events.forEach((event) => {
+      if (!event.type?.text) {
+        return;
+      }
+
+      const match = /^CustomEvent<(.+)>$/.exec(event.type.text);
+      if (!match) {
+        return;
+      }
+
+      const detail = match[1].trim();
+      if (/^[A-Z][\w$]*$/.test(detail)) {
+        addImport(imports, importPath, detail);
+      }
+    });
+  });
+
   return Array.from(imports.entries())
     .map(
       ([importPath, exportNames]) =>

--- a/test/type-generator.test.ts
+++ b/test/type-generator.test.ts
@@ -176,6 +176,41 @@ const parsedTypeManifest: ExtendedPackage = {
   ],
 };
 
+const eventDetailManifest = {
+  schemaVersion: "1.0.0",
+  readme: "",
+  modules: [
+    {
+      kind: "javascript-module",
+      path: "src/my-button.ts",
+      declarations: [
+        {
+          kind: "class",
+          name: "MyButton",
+          tagName: "my-button",
+          customElement: true,
+          events: [
+            {
+              name: "my-change",
+              type: { text: "CustomEvent<MyDetail>" },
+            },
+          ],
+        },
+      ],
+      exports: [
+        {
+          kind: "js",
+          name: "MyButton",
+          declaration: {
+            name: "MyButton",
+            module: "src/my-button.ts",
+          },
+        },
+      ],
+    },
+  ],
+} satisfies cem.Package;
+
 describe("generateJsxTypes", () => {
   it("includes the global role attribute in BaseProps", () => {
     const template = generateJsxTypes(manifest as cem.Package, {
@@ -229,5 +264,77 @@ describe("generateJsxTypes", () => {
     );
     expect(template).toContain('"variant"?: ButtonVariant | undefined;');
     expect(template).toContain('"size"?: ButtonSize;');
+  });
+
+  it("imports a named CustomEvent detail type alongside the component", () => {
+    const template = generateJsxTypes(eventDetailManifest, {
+      fileName: undefined,
+      stronglyTypedEvents: true,
+    });
+
+    expect(template).toMatch(
+      /import type \{ [^}]*MyButton[^}]*MyDetail[^}]*\} from "src\/my-button.ts"/,
+    );
+    expect(template).toContain(
+      "export type MyButtonMyChangeElementEvent = MyButtonElementEvent<CustomEvent<MyDetail>>;",
+    );
+  });
+
+  it("does not import a union CustomEvent detail type", () => {
+    const unionManifest = {
+      schemaVersion: "1.0.0",
+      readme: "",
+      modules: [
+        {
+          kind: "javascript-module",
+          path: "src/my-button.ts",
+          declarations: [
+            {
+              kind: "class",
+              name: "MyButton",
+              tagName: "my-button",
+              customElement: true,
+              events: [
+                {
+                  name: "my-change",
+                  type: { text: "CustomEvent<Foo | Bar>" },
+                },
+              ],
+            },
+          ],
+          exports: [
+            {
+              kind: "js",
+              name: "MyButton",
+              declaration: {
+                name: "MyButton",
+                module: "src/my-button.ts",
+              },
+            },
+          ],
+        },
+      ],
+    } satisfies cem.Package;
+
+    const template = generateJsxTypes(unionManifest, {
+      fileName: undefined,
+      stronglyTypedEvents: true,
+    });
+
+    expect(template).not.toMatch(/import [^}]*\|[^}]*\} from/);
+  });
+
+  it("imports event detail type even without strongly typed events", () => {
+    const template = generateJsxTypes(eventDetailManifest, {
+      fileName: undefined,
+      stronglyTypedEvents: false,
+    });
+
+    expect(template).toMatch(
+      /import type \{ [^}]*MyDetail[^}]*\} from "src\/my-button.ts"/,
+    );
+    expect(template).toContain(
+      '  "onmy-change"?: (e: CustomEvent<MyDetail>) => void;',
+    );
   });
 });


### PR DESCRIPTION
## Summary

`generateJsxTypes` with `stronglyTypedEvents: true` produces a `.d.ts` that does not type-check whenever an event's `detail` is a named type written as `CustomEvent<Detail>` (the shape most CEMs emit). The detail type referenced by the generated aliases is never imported, because `getImports()` only resolves imports for component classes and property type references — not for event detail types.

`getImports()` now also recovers the inner named type from `CustomEvent<...>` events and imports it alongside the element. A single named identifier is taken; unions, nested generics, arrays and namespaced details have no single importable name and are left as-is. The detail is assumed to be a named export of the element's module, matching the convention already used elsewhere in the generator.

The change is additive: events with a bare `Event`/`CustomEvent` type, components without typed event details, and inline object literals generate byte-identical output — only the previously-broken typed-`CustomEvent` output changes.

## Testing

- `pnpm test` — added cases for a named detail (imported alongside the component), a union detail (not spliced into the import), and a non-strong-mode handler typing that still imports the detail.
- `pnpm lint`
- `pnpm build`

## Checklist

- Added tests
- Added a changeset
- Existing tests pass
- Output verified for a mixed manifest